### PR TITLE
Switch "R" and "C" in (E|RC|NM)*

### DIFF
--- a/crossword.js
+++ b/crossword.js
@@ -6,7 +6,7 @@ var board_data = {
     '[^X]*(DN|TE|NI)'
     ,'[RONMHC]*I[RONMHC]*'
     ,'.*(..)\\1P+'
-    ,'(E|RC|NM)*'
+    ,'(E|CR|NM)*'
     ,'([^MC]|MM|CC)*'
     ,'R?(CR)*MC[MA]*'
     ,'.*'


### PR DESCRIPTION
Hey, thanks for your puzzle, it was fun to attempt 💚 I think I found a typo in the exercise:

The `(E|RC|NM)*` pattern, specifically the `RC` in it, should be `CR`.

This is because of two reasons.

1. We can conclude that the very last cell must be an `R` due to the other two constraints on that row. <br /><details>
    <summary>Image hidden, as it contains spoilers. Click to expand!</summary>
    <img width="1045" alt="Screenshot 2021-03-12 at 22 14 11" src="https://user-images.githubusercontent.com/206108/111000245-f935bb00-8381-11eb-9c76-eda4e50bf58d.png">
  </details>

2. This is how the [original puzzle defines it](https://web.mit.edu/puzzle/www/2013/coinheist.com/rubik/a_regular_crossword/answer/) ;) <br /><details>
    <summary>Image hidden, as it contains spoilers. Click to expand!</summary>
    <img width="836" alt="Screenshot 2021-03-12 at 22 25 20" src="https://user-images.githubusercontent.com/206108/111000254-fcc94200-8381-11eb-84fa-8559ab1b4322.png">
  </details>
