### PR TITLE
Highlight relevant rules on cell focs

### DIFF
--- a/crossword.css
+++ b/crossword.css
@@ -95,6 +95,10 @@ body
 .nomatch {
   color: #C00;
 }
+.highlighted {
+  font-weight: bold;
+  text-decoration: underline;
+}
 
 span {
   -border: 1px dotted black;

--- a/crossword.js
+++ b/crossword.js
@@ -212,6 +212,20 @@ function onFocusCell() {
   var elem = $('#' + this.id.slice('wrap_'.length));
   elem.focus();
   elem.select();
+
+  // Deselect all previous highlighted rules
+  $('.highlighted').removeClass('highlighted');
+
+  // Get position of current cell
+  const pos_match = this.id.match(/wrap_cell_(\d+)_(\d+)/);
+  const y = parseInt(pos_match[1], 10);
+  const x = parseInt(pos_match[2], 10);
+  const z = y < 6 ? x - y + 6 : x;
+  
+  // Set the relevant rules as highlighted
+  $('#rule_x_' + x).addClass('highlighted');
+  $('#rule_y_' + y).addClass('highlighted');
+  $('#rule_z_' + z).addClass('highlighted');
 }
 
 function reset() {


### PR DESCRIPTION
This is a fix for https://github.com/Jimbly/regex-crossword/issues/8

It simply highlights the three relevant rules when a cell is selected.

Open questions:
1. Is bold + underline good? Other ways of highlighting?
2. Should we unhighlight on focus loss or clicking outside?
3. Should we also highlight the cell itself
4. Extra: should we also highlight all 3 rows connected to the cell?