### PR TITLE
make format description consistent

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <body>
     <script>/*workaround for ff bug 1404468*/</script>
     It's a crossword puzzle where you need to fill in the hexes with character sequences, so that they match the regular expressions listed around the edges.<br/>
-    The individual clues will turn <span class="match"><span class="mode_colorblind">bold purple</span><span class="mode_normal">green</span></span> when satisfied, <span class="nomatch"><span class="mode_colorblind">orange</span><span class="mode_normal">red</span></span> when not, and <span class="highlighted">underlined</span> when active.<br />
+    The individual clues will turn <span class="match"><span class="mode_colorblind">bold purple</span><span class="mode_normal">bold green</span></span> when satisfied, <span class="nomatch"><span class="mode_colorblind">orange</span><span class="mode_normal">red</span></span> when not, and <span class="highlighted">underlined</span> when active.<br />
     Note that the regex must be a full match, and empty cells are treated as spaces.<br/>
     <span class="edit">Double click a rule to edit it.  When finished, press 'enter'.<br/></span>
     <table><tr>


### PR DESCRIPTION
Matched clues are bold in normal and colorblind modes, but the text only says “bold” in colorblind mode. This adds “bold” to the normal mode text.